### PR TITLE
[FEAT] spring security 관련 작업

### DIFF
--- a/src/main/java/io/github/bunmo/file/common/exception/BusinessException.java
+++ b/src/main/java/io/github/bunmo/file/common/exception/BusinessException.java
@@ -1,0 +1,14 @@
+package io.github.bunmo.file.common.exception;
+
+public class BusinessException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.message());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode errorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/io/github/bunmo/file/common/exception/ErrorCode.java
+++ b/src/main/java/io/github/bunmo/file/common/exception/ErrorCode.java
@@ -1,0 +1,9 @@
+package io.github.bunmo.file.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    HttpStatus statusCode();
+    String code();
+    String message();
+}

--- a/src/main/java/io/github/bunmo/file/common/web/ApiResponse.java
+++ b/src/main/java/io/github/bunmo/file/common/web/ApiResponse.java
@@ -32,6 +32,6 @@ public class ApiResponse<T> {
     }
 
     public static ApiResponse<Void> error(ErrorCode errorCode) {
-        return new ApiResponse(errorCode.code(), errorCode.message(), null, null);
+        return new ApiResponse<>(errorCode.code(), errorCode.message(), null, null);
     }
 }

--- a/src/main/java/io/github/bunmo/file/common/web/ApiResponse.java
+++ b/src/main/java/io/github/bunmo/file/common/web/ApiResponse.java
@@ -1,0 +1,37 @@
+package io.github.bunmo.file.common.web;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import io.github.bunmo.file.common.exception.ErrorCode;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({"code", "message", "data", "errors"})
+public class ApiResponse<T> {
+    @Schema(description = "결과 코드", example = "OAUTH_001")
+    private final String code;
+    @Schema(description = "결과 메시지", example = "카카오 사용자 정보 요청에 실패했습니다")
+    private final String message;
+    @Schema(description = "요청에 대한 응답 데이터", example = "{\"id\":\"1\"}")
+    private final T data;
+    private final List<FieldError> errors;
+
+    private ApiResponse(String code, String message, T data, List<FieldError> errors) {
+        this.code = code;
+        this.message = message;
+        this.data = data;
+        this.errors = errors;
+    }
+
+    public record FieldError(String field, String message) {}
+
+    public static <T> ApiResponse<T> success(ResultCode resultCode, T data) {
+        return new ApiResponse<>(resultCode.code(), resultCode.message(), data, null);
+    }
+
+    public static ApiResponse<Void> error(ErrorCode errorCode) {
+        return new ApiResponse(errorCode.code(), errorCode.message(), null, null);
+    }
+}

--- a/src/main/java/io/github/bunmo/file/common/web/ResultCode.java
+++ b/src/main/java/io/github/bunmo/file/common/web/ResultCode.java
@@ -1,0 +1,9 @@
+package io.github.bunmo.file.common.web;
+
+import org.springframework.http.HttpStatus;
+
+public interface ResultCode {
+    HttpStatus statusCode();
+    String code();
+    String message();
+}

--- a/src/main/java/io/github/bunmo/file/member/domain/Member.java
+++ b/src/main/java/io/github/bunmo/file/member/domain/Member.java
@@ -1,0 +1,35 @@
+package io.github.bunmo.file.member.domain;
+
+import io.github.bunmo.file.member.domain.enums.ActiveType;
+import io.github.bunmo.file.member.domain.enums.RoleType;
+import jakarta.persistence.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(name = "member")
+@EntityListeners(AuditingEntityListener.class)
+public class Member {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, updatable = false)
+    private String uuid;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "active_type", nullable = false)
+    private ActiveType activeType;
+
+    @Enumerated(EnumType.STRING)
+    private RoleType role;
+
+    protected Member() { }
+
+    public String getUuid() {
+        return uuid;
+    }
+
+    public RoleType role() {
+        return role;
+    }
+}

--- a/src/main/java/io/github/bunmo/file/member/domain/enums/ActiveType.java
+++ b/src/main/java/io/github/bunmo/file/member/domain/enums/ActiveType.java
@@ -1,0 +1,9 @@
+package io.github.bunmo.file.member.domain.enums;
+
+public enum ActiveType {
+    PENDING, ACTIVE, INACTIVE, BANNED, WITHDRAWAL;
+
+    public boolean isValid() {
+        return this == ACTIVE || this == PENDING;
+    }
+}

--- a/src/main/java/io/github/bunmo/file/member/domain/enums/RoleType.java
+++ b/src/main/java/io/github/bunmo/file/member/domain/enums/RoleType.java
@@ -1,0 +1,6 @@
+package io.github.bunmo.file.member.domain.enums;
+
+public enum RoleType {
+    ADMIN,
+    MEMBER,
+}

--- a/src/main/java/io/github/bunmo/file/member/infrastructure/repository/MemberRepository.java
+++ b/src/main/java/io/github/bunmo/file/member/infrastructure/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package io.github.bunmo.file.member.infrastructure.repository;
+
+import io.github.bunmo.file.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+    Optional<Member> findByUuid(String uuid);
+}

--- a/src/main/java/io/github/bunmo/file/security/CustomUserDetails.java
+++ b/src/main/java/io/github/bunmo/file/security/CustomUserDetails.java
@@ -1,0 +1,39 @@
+package io.github.bunmo.file.security;
+
+import io.github.bunmo.file.member.domain.Member;
+import io.github.bunmo.file.member.domain.enums.RoleType;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+public class CustomUserDetails implements UserDetails {
+    private String uuid;
+    private RoleType role;
+
+    private CustomUserDetails(String uuid, RoleType role) {
+        this.uuid = uuid;
+        this.role = role;
+    }
+
+    public static CustomUserDetails from(Member member) {
+        return new CustomUserDetails(member.getUuid(), member.role());
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_" + role.toString()));
+    }
+
+    @Override
+    public String getPassword() {
+        return "";
+    }
+
+    @Override
+    public String getUsername() {
+        return uuid;
+    }
+}

--- a/src/main/java/io/github/bunmo/file/security/JwtFilter.java
+++ b/src/main/java/io/github/bunmo/file/security/JwtFilter.java
@@ -1,0 +1,68 @@
+package io.github.bunmo.file.security;
+
+
+import io.github.bunmo.file.security.exception.AuthException;
+import io.github.bunmo.file.security.jwt.JwtUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class JwtFilter extends OncePerRequestFilter {
+    private final Logger log = LoggerFactory.getLogger(JwtFilter.class);
+    private final JwtUtil jwtUtil;
+    private final UserDetailsService userDetailsService;
+    private static final String AUTHORIZATION_HEADER = "Authorization";
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    public  JwtFilter(JwtUtil jwtUtil, UserDetailsService userDetailsService) {
+        this.jwtUtil = jwtUtil;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
+
+        if (StringUtils.hasText(token) && jwtUtil.validateToken(token)) {
+            try {
+                String uuid = jwtUtil.getSubject(token);
+                UserDetails userDetails = userDetailsService.loadUserByUsername(uuid);
+                Authentication authentication = new UsernamePasswordAuthenticationToken(
+                        userDetails,
+                        token,
+                        userDetails.getAuthorities()
+                );
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } catch (UsernameNotFoundException | AuthException e) {
+                log.debug("JWT authentication failed.", e);
+                SecurityContextHolder.clearContext();
+            }
+        } else {
+            log.debug("유효한 JWT 토큰이 없습니다.");
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/io/github/bunmo/file/security/config/SecurityConfig.java
+++ b/src/main/java/io/github/bunmo/file/security/config/SecurityConfig.java
@@ -1,0 +1,88 @@
+package io.github.bunmo.file.security.config;
+
+import io.github.bunmo.file.security.JwtFilter;
+import io.github.bunmo.file.security.jwt.JwtAccessDeniedHandler;
+import io.github.bunmo.file.security.jwt.JwtAuthenticationEntryPoint;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final AuthenticationConfiguration authenticationConfiguration;
+    private final JwtFilter jwtFilter;
+
+    public SecurityConfig(
+            final JwtAccessDeniedHandler jwtAccessDeniedHandler,
+            final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint,
+            final AuthenticationConfiguration authenticationConfiguration,
+            final JwtFilter jwtFilter
+    ) {
+        this.jwtAccessDeniedHandler = jwtAccessDeniedHandler;
+        this.jwtAuthenticationEntryPoint = jwtAuthenticationEntryPoint;
+        this.authenticationConfiguration = authenticationConfiguration;
+        this.jwtFilter = jwtFilter;
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager() throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        return request -> {
+            CorsConfiguration configuration = new CorsConfiguration();
+            configuration.setAllowedOrigins(Arrays.asList("http://localhost:6004"));
+            configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+            configuration.setAllowCredentials(true);
+            configuration.setAllowedHeaders(Collections.singletonList("*"));
+            configuration.setExposedHeaders(Collections.singletonList("Authorization"));
+            configuration.setAllowCredentials(true);
+            return configuration;
+        };
+    }
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http, AuthenticationManager authenticationManager) throws Exception {
+        return http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .csrf(csrf -> csrf.disable())
+                .formLogin(form -> form.disable())
+                .httpBasic(httpBasic -> httpBasic.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                        .accessDeniedHandler(jwtAccessDeniedHandler))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/api-docs/**",
+                                "/swagger-ui/**"
+                        ).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+                .build();
+
+    }
+}

--- a/src/main/java/io/github/bunmo/file/security/config/SecurityConfig.java
+++ b/src/main/java/io/github/bunmo/file/security/config/SecurityConfig.java
@@ -64,7 +64,7 @@ public class SecurityConfig {
     }
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http, AuthenticationManager authenticationManager) throws Exception {
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         return http
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(csrf -> csrf.disable())

--- a/src/main/java/io/github/bunmo/file/security/exception/AuthErrorCode.java
+++ b/src/main/java/io/github/bunmo/file/security/exception/AuthErrorCode.java
@@ -1,0 +1,38 @@
+package io.github.bunmo.file.security.exception;
+
+import io.github.bunmo.file.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum AuthErrorCode implements ErrorCode {
+    INVALID_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED_001", "유효하지 않은 토큰입니다"),
+    EXPIRED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED_002", "만료된 토큰입니다"),
+    UNSUPPORTED_JWT_TOKEN(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED_003", "지원하지 않는 토큰입니다"),
+    ACCESS_DENIED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED_004", "접근이 거부되었습니다"),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED_005", "인증이 필요합니다"),
+    ;
+
+    private final HttpStatus statusCode;
+    private final String code;
+    private final String message;
+
+    AuthErrorCode(HttpStatus statusCode, String code, String message) {
+        this.statusCode = statusCode;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus statusCode() {
+        return this.statusCode;
+    }
+
+    @Override
+    public String code() {
+        return this.code;
+    }
+
+    @Override
+    public String message() {
+        return this.message;
+    }
+}

--- a/src/main/java/io/github/bunmo/file/security/exception/AuthException.java
+++ b/src/main/java/io/github/bunmo/file/security/exception/AuthException.java
@@ -1,0 +1,16 @@
+package io.github.bunmo.file.security.exception;
+
+import io.github.bunmo.file.common.exception.ErrorCode;
+
+public class AuthException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public AuthException(ErrorCode errorCode) {
+        super(errorCode.message());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode errorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/io/github/bunmo/file/security/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/io/github/bunmo/file/security/jwt/JwtAccessDeniedHandler.java
@@ -31,7 +31,7 @@ public class JwtAccessDeniedHandler implements AccessDeniedHandler {
 
         String responseBody = objectMapper.writeValueAsString(apiResponse);
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setStatus(HttpStatus.FORBIDDEN.value());
         response.setCharacterEncoding("UTF-8");
         response.getWriter().write(responseBody);
     }

--- a/src/main/java/io/github/bunmo/file/security/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/io/github/bunmo/file/security/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,38 @@
+package io.github.bunmo.file.security.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.bunmo.file.common.web.ApiResponse;
+import io.github.bunmo.file.security.exception.AuthErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+    private final ObjectMapper objectMapper;
+
+    public JwtAccessDeniedHandler(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void handle(
+            final HttpServletRequest request,
+            final HttpServletResponse response,
+            final AccessDeniedException accessDeniedException
+    ) throws IOException {
+        ApiResponse<Void> apiResponse = ApiResponse.error(AuthErrorCode.ACCESS_DENIED);
+
+        String responseBody = objectMapper.writeValueAsString(apiResponse);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(responseBody);
+    }
+}

--- a/src/main/java/io/github/bunmo/file/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/io/github/bunmo/file/security/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,34 @@
+package io.github.bunmo.file.security.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.bunmo.file.common.web.ApiResponse;
+import io.github.bunmo.file.security.exception.AuthErrorCode;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper;
+
+    public JwtAuthenticationEntryPoint(final ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        ApiResponse<Void> apiResponse = ApiResponse.error(AuthErrorCode.UNAUTHORIZED);
+
+        String responseBody = objectMapper.writeValueAsString(apiResponse);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(responseBody);
+    }
+}

--- a/src/main/java/io/github/bunmo/file/security/jwt/JwtUtil.java
+++ b/src/main/java/io/github/bunmo/file/security/jwt/JwtUtil.java
@@ -1,24 +1,16 @@
 package io.github.bunmo.file.security.jwt;
 
-
-import io.github.bunmo.file.security.exception.AuthErrorCode;
-import io.github.bunmo.file.security.exception.AuthException;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
-import java.util.Arrays;
 import java.util.Base64;
-import java.util.Collection;
 import java.util.Date;
 import java.util.stream.Collectors;
 
@@ -62,26 +54,12 @@ public class JwtUtil {
             log.error("잘 못된 JWT 서명입니다");
         } catch (ExpiredJwtException e) {
             log.error("만료된 JWT 토큰입니다.");
-            throw new AuthException(AuthErrorCode.EXPIRED_JWT_TOKEN);
         } catch (UnsupportedJwtException e) {
             log.error("지원되지 않는 JWT 토큰입니다.");
         } catch (IllegalArgumentException e) {
             log.error("JWT 토큰이 잘못되었습니다.");
         }
         return false;
-    }
-
-    public Authentication getAuthentication(String token) {
-        Claims claims = parseClaims(token);
-
-        Collection<? extends GrantedAuthority> authorities =
-                Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
-                        .filter(auth -> !auth.trim().isEmpty())
-                        .map(SimpleGrantedAuthority::new)
-                        .toList();
-        User principle = new User(claims.getSubject(), "", authorities);
-
-        return new UsernamePasswordAuthenticationToken(principle, token, authorities);
     }
 
     public String getSubject(String token) {

--- a/src/main/java/io/github/bunmo/file/security/jwt/JwtUtil.java
+++ b/src/main/java/io/github/bunmo/file/security/jwt/JwtUtil.java
@@ -1,0 +1,116 @@
+package io.github.bunmo.file.security.jwt;
+
+
+import io.github.bunmo.file.security.exception.AuthErrorCode;
+import io.github.bunmo.file.security.exception.AuthException;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+@Component
+public class JwtUtil {
+    private final SecretKey key;
+    private final long accessTokenExpireTime;
+    private final long refreshTokenExpireTime;
+    private static final String AUTHORITIES_KEY = "roles";
+
+    private final Logger log = LoggerFactory.getLogger(this.getClass());
+
+    public JwtUtil(
+            @Value("${jwt.secret}") String secretKey,
+            @Value("${jwt.access-token.expire-time}") long accessTokenExpireTime,
+            @Value("${jwt.refresh-token.expire-time}") long refreshTokenExpireTime
+    ) {
+        byte[] keyBytes = Base64.getDecoder().decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+        this.accessTokenExpireTime = accessTokenExpireTime;
+        this.refreshTokenExpireTime = refreshTokenExpireTime;
+    }
+
+    public String createAccessToken(Authentication authentication) {
+        return generateToken(authentication, accessTokenExpireTime);
+    }
+
+    public String createRefreshToken(Authentication authentication) {
+        return generateToken(authentication, refreshTokenExpireTime);
+    }
+
+    public Long getAccessTokenValidity() {
+        return accessTokenExpireTime / 1000;
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (SecurityException | MalformedJwtException e) {
+            log.error("잘 못된 JWT 서명입니다");
+        } catch (ExpiredJwtException e) {
+            log.error("만료된 JWT 토큰입니다.");
+            throw new AuthException(AuthErrorCode.EXPIRED_JWT_TOKEN);
+        } catch (UnsupportedJwtException e) {
+            log.error("지원되지 않는 JWT 토큰입니다.");
+        } catch (IllegalArgumentException e) {
+            log.error("JWT 토큰이 잘못되었습니다.");
+        }
+        return false;
+    }
+
+    public Authentication getAuthentication(String token) {
+        Claims claims = parseClaims(token);
+
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
+                        .filter(auth -> !auth.trim().isEmpty())
+                        .map(SimpleGrantedAuthority::new)
+                        .toList();
+        User principle = new User(claims.getSubject(), "", authorities);
+
+        return new UsernamePasswordAuthenticationToken(principle, token, authorities);
+    }
+
+    public String getSubject(String token) {
+        return parseClaims(token).getSubject();
+    }
+
+    private String generateToken(Authentication authentication, long expireTime) {
+        String authorities = authentication.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .collect(Collectors.joining(","));
+
+        Date now = new Date(System.currentTimeMillis());
+        Date expiryDate = new Date(System.currentTimeMillis() + expireTime);
+
+        return Jwts.builder()
+                .subject(authentication.getName())
+                .claim(AUTHORITIES_KEY, authorities)
+                .issuedAt(now)
+                .expiration(expiryDate)
+                .signWith(key)
+                .compact();
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+}

--- a/src/main/java/io/github/bunmo/file/security/service/CustomUserDetailsService.java
+++ b/src/main/java/io/github/bunmo/file/security/service/CustomUserDetailsService.java
@@ -21,8 +21,8 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     @Transactional(readOnly = true)
-    public UserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
-        Member member = memberRepository.findById(Long.parseLong(id))
+    public UserDetails loadUserByUsername(String uuid) throws UsernameNotFoundException {
+        Member member = memberRepository.findByUuid(uuid)
                 .orElseThrow(() -> new AuthException(AuthErrorCode.ACCESS_DENIED));
 
         return CustomUserDetails.from(member);

--- a/src/main/java/io/github/bunmo/file/security/service/CustomUserDetailsService.java
+++ b/src/main/java/io/github/bunmo/file/security/service/CustomUserDetailsService.java
@@ -1,0 +1,30 @@
+package io.github.bunmo.file.security.service;
+
+import io.github.bunmo.file.member.domain.Member;
+import io.github.bunmo.file.member.infrastructure.repository.MemberRepository;
+import io.github.bunmo.file.security.CustomUserDetails;
+import io.github.bunmo.file.security.exception.AuthErrorCode;
+import io.github.bunmo.file.security.exception.AuthException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+    private final MemberRepository memberRepository;
+
+    public CustomUserDetailsService(final MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
+        Member member = memberRepository.findById(Long.parseLong(id))
+                .orElseThrow(() -> new AuthException(AuthErrorCode.ACCESS_DENIED));
+
+        return CustomUserDetails.from(member);
+    }
+}


### PR DESCRIPTION
# 연관된 이슈
close #1 

# 작업 내용
- 파일 업로드 / 다운로드 api 서버에 인증 인가 로직을 위한 스프링 시큐리티 추가

# 도입 이유
- api 서버와 파일 업로드/다운로드 api 서버를 분리 -> 파일 api 서버에도 인증/인가 필요

[리뷰 요구사항]
- api 서버와 파일 api 서버에 인증/인가 로직이 중복됨
- 인증/인가 로직 변경시 각각 업데이트 필요함
- 추후 인증 서버 분리 도입 고려 중
- 최소한의 의존성으로 작업하고 싶은데 어디를 더 덜어낼 수 있을지
- 
