### PR TITLE
[FEAT] 썸네일 이미지 업로드 & 다운로드

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
+    implementation 'io.minio:minio:8.5.17'
+
     developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
     runtimeOnly 'org.springframework.boot:spring-boot-docker-compose'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,1 +1,0 @@
-services: { }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,33 @@
+services:
+  minio:
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z-cpuv1
+    container_name: minio
+    command: server /data --console-address ":9001"
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    environment:
+      MINIO_ROOT_USER: minio_root_user
+      MINIO_ROOT_PASSWORD: minio_root_password
+      MINIO_API_CORS_ALLOW_ORIGIN: "http://localhost:3000,http://127.0.0.1:3000"
+    volumes:
+      - minio_data:/data
+  minio-init:
+    image: minio/mc:latest
+    depends_on:
+      - minio
+    environment:
+      MINIO_ROOT_USER: minio_root_user
+      MINIO_ROOT_PASSWORD: minio_root_password
+    entrypoint: >
+        /bin/sh -c "
+        until mc alias set local http://minio:9000 minio_root_user minio_root_password; do sleep 2; done;
+        mc mb --ignore-existing local/uploads-raw;
+        mc mb --ignore-existing local/profile;
+        mc anonymous set none local/uploads-raw;
+        mc anonymous set none local/profile;
+        exit 0;
+        "
+
+volumes:
+  minio_data:

--- a/src/main/java/io/github/bunmo/file/common/util/FilePathGenerator.java
+++ b/src/main/java/io/github/bunmo/file/common/util/FilePathGenerator.java
@@ -1,0 +1,8 @@
+package io.github.bunmo.file.common.util;
+
+public class FilePathGenerator {
+
+    public static String generateProfileFilePath(String uuid, Long timestamp) {
+        return uuid + "/profile/" + timestamp;
+    }
+}

--- a/src/main/java/io/github/bunmo/file/common/web/ApiResponse.java
+++ b/src/main/java/io/github/bunmo/file/common/web/ApiResponse.java
@@ -34,4 +34,20 @@ public class ApiResponse<T> {
     public static ApiResponse<Void> error(ErrorCode errorCode) {
         return new ApiResponse<>(errorCode.code(), errorCode.message(), null, null);
     }
+
+    public String getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public T getData() {
+        return data;
+    }
+
+    public List<FieldError> getErrors() {
+        return errors;
+    }
 }

--- a/src/main/java/io/github/bunmo/file/common/web/GlobalControllerAdvice.java
+++ b/src/main/java/io/github/bunmo/file/common/web/GlobalControllerAdvice.java
@@ -1,0 +1,21 @@
+package io.github.bunmo.file.common.web;
+
+import io.github.bunmo.file.common.exception.BusinessException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalControllerAdvice {
+    private final Logger log = LoggerFactory.getLogger(GlobalControllerAdvice.class);
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<?> handleCustomException(BusinessException e) {
+        log.debug(e.getMessage());
+        return ResponseEntity
+                .status(e.errorCode().statusCode())
+                .body(ApiResponse.error(e.errorCode()));
+    }
+}

--- a/src/main/java/io/github/bunmo/file/file/application/FileService.java
+++ b/src/main/java/io/github/bunmo/file/file/application/FileService.java
@@ -1,0 +1,112 @@
+package io.github.bunmo.file.file.application;
+
+import io.github.bunmo.file.file.exception.FileErrorCode;
+import io.github.bunmo.file.file.exception.FileException;
+import io.github.bunmo.file.file.infrastructure.storage.StorageClient;
+import io.github.bunmo.file.file.presentation.dto.ProfileUploadResponse;
+import io.github.bunmo.file.member.domain.Member;
+import io.github.bunmo.file.member.infrastructure.repository.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.InputStream;
+import java.util.Set;
+
+@Service
+public class FileService {
+
+    private static final Set<String> ALLOWED_IMAGE_TYPES = Set.of(
+            "image/jpeg",
+            "image/png",
+            "image/webp"
+    );
+
+    private static final long MAX_FILE_SIZE = 2 * 1024 * 1024;
+
+    private final StorageClient storageClient;
+    private final MemberRepository memberRepository;
+
+    public FileService(StorageClient storageClient, MemberRepository memberRepository) {
+        this.storageClient = storageClient;
+        this.memberRepository = memberRepository;
+    }
+
+    @Transactional
+    public ProfileUploadResponse uploadProfileImage(String uuid, MultipartFile file) {
+        validateFile(file);
+
+        Member member = memberRepository.findByUuid(uuid)
+                .orElseThrow(() -> new FileException(FileErrorCode.MEMBER_NOT_FOUND));
+
+        String objectName = buildProfileObjectName(uuid);
+
+        if (member.getProfileImageUrl() != null) {
+            storageClient.delete(objectName);
+        }
+
+        try (InputStream inputStream = file.getInputStream()) {
+            storageClient.upload(objectName, inputStream, file.getSize(), file.getContentType());
+        } catch (FileException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new FileException(FileErrorCode.FILE_UPLOAD_FAILED);
+        }
+
+        String profileUrl = "/api/v1/files/profile/" + uuid;
+        member.updateProfileImageUrl(profileUrl);
+
+        return ProfileUploadResponse.of(uuid);
+    }
+
+    @Transactional(readOnly = true)
+    public ProfileImageData getProfileImage(String uuid) {
+        Member member = memberRepository.findByUuid(uuid)
+                .orElseThrow(() -> new FileException(FileErrorCode.MEMBER_NOT_FOUND));
+
+        if (member.getProfileImageUrl() == null) {
+            throw new FileException(FileErrorCode.FILE_NOT_FOUND);
+        }
+
+        String objectName = buildProfileObjectName(uuid);
+        InputStream inputStream = storageClient.download(objectName);
+        String etag = storageClient.getETag(objectName);
+        String contentType = storageClient.getContentType(objectName);
+
+        return new ProfileImageData(inputStream, contentType, etag);
+    }
+
+    @Transactional
+    public void deleteProfileImage(String uuid) {
+        Member member = memberRepository.findByUuid(uuid)
+                .orElseThrow(() -> new FileException(FileErrorCode.MEMBER_NOT_FOUND));
+
+        if (member.getProfileImageUrl() == null) {
+            throw new FileException(FileErrorCode.FILE_NOT_FOUND);
+        }
+
+        String objectName = buildProfileObjectName(uuid);
+        storageClient.delete(objectName);
+        member.updateProfileImageUrl(null);
+    }
+
+    private void validateFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new FileException(FileErrorCode.FILE_NOT_FOUND);
+        }
+
+        if (!ALLOWED_IMAGE_TYPES.contains(file.getContentType())) {
+            throw new FileException(FileErrorCode.INVALID_FILE_TYPE);
+        }
+
+        if (file.getSize() > MAX_FILE_SIZE) {
+            throw new FileException(FileErrorCode.FILE_SIZE_EXCEEDED);
+        }
+    }
+
+    private String buildProfileObjectName(String uuid) {
+        return "profiles/" + uuid;
+    }
+
+    public record ProfileImageData(InputStream inputStream, String contentType, String etag) {}
+}

--- a/src/main/java/io/github/bunmo/file/file/application/FileService.java
+++ b/src/main/java/io/github/bunmo/file/file/application/FileService.java
@@ -1,5 +1,6 @@
 package io.github.bunmo.file.file.application;
 
+import io.github.bunmo.file.common.util.FilePathGenerator;
 import io.github.bunmo.file.file.exception.FileErrorCode;
 import io.github.bunmo.file.file.exception.FileException;
 import io.github.bunmo.file.file.infrastructure.storage.StorageClient;
@@ -39,10 +40,11 @@ public class FileService {
         Member member = memberRepository.findByUuid(uuid)
                 .orElseThrow(() -> new FileException(FileErrorCode.MEMBER_NOT_FOUND));
 
-        String objectName = buildProfileObjectName(uuid);
+        Long timestamp = System.currentTimeMillis();
+        String objectName = FilePathGenerator.generateProfileFilePath(uuid, timestamp);
 
         if (member.getProfileImageUrl() != null) {
-            storageClient.delete(objectName);
+            storageClient.delete(member.getProfileImageUrl());
         }
 
         try (InputStream inputStream = file.getInputStream()) {
@@ -53,14 +55,13 @@ public class FileService {
             throw new FileException(FileErrorCode.FILE_UPLOAD_FAILED);
         }
 
-        String profileUrl = "/api/v1/files/profile/" + uuid;
-        member.updateProfileImageUrl(profileUrl);
+        member.updateProfileImageUrl(objectName);
 
-        return ProfileUploadResponse.of(uuid);
+        return ProfileUploadResponse.of(objectName);
     }
 
     @Transactional(readOnly = true)
-    public ProfileImageData getProfileImage(String uuid) {
+    public ProfileImageData getProfileImage(String uuid, Long timestamp) {
         Member member = memberRepository.findByUuid(uuid)
                 .orElseThrow(() -> new FileException(FileErrorCode.MEMBER_NOT_FOUND));
 
@@ -68,26 +69,12 @@ public class FileService {
             throw new FileException(FileErrorCode.FILE_NOT_FOUND);
         }
 
-        String objectName = buildProfileObjectName(uuid);
+        String objectName = FilePathGenerator.generateProfileFilePath(uuid, timestamp);
         InputStream inputStream = storageClient.download(objectName);
         String etag = storageClient.getETag(objectName);
         String contentType = storageClient.getContentType(objectName);
 
         return new ProfileImageData(inputStream, contentType, etag);
-    }
-
-    @Transactional
-    public void deleteProfileImage(String uuid) {
-        Member member = memberRepository.findByUuid(uuid)
-                .orElseThrow(() -> new FileException(FileErrorCode.MEMBER_NOT_FOUND));
-
-        if (member.getProfileImageUrl() == null) {
-            throw new FileException(FileErrorCode.FILE_NOT_FOUND);
-        }
-
-        String objectName = buildProfileObjectName(uuid);
-        storageClient.delete(objectName);
-        member.updateProfileImageUrl(null);
     }
 
     private void validateFile(MultipartFile file) {
@@ -102,10 +89,6 @@ public class FileService {
         if (file.getSize() > MAX_FILE_SIZE) {
             throw new FileException(FileErrorCode.FILE_SIZE_EXCEEDED);
         }
-    }
-
-    private String buildProfileObjectName(String uuid) {
-        return "profiles/" + uuid;
     }
 
     public record ProfileImageData(InputStream inputStream, String contentType, String etag) {}

--- a/src/main/java/io/github/bunmo/file/file/exception/FileErrorCode.java
+++ b/src/main/java/io/github/bunmo/file/file/exception/FileErrorCode.java
@@ -1,0 +1,41 @@
+package io.github.bunmo.file.file.exception;
+
+import io.github.bunmo.file.common.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum FileErrorCode implements ErrorCode {
+    FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "FILE_001", "파일을 찾을 수 없습니다"),
+    FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_002", "파일 업로드에 실패했습니다"),
+    FILE_DOWNLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_003", "파일 다운로드에 실패했습니다"),
+    FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_004", "파일 삭제에 실패했습니다"),
+    FILE_OPERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE_005", "파일 작업에 실패했습니다"),
+    INVALID_FILE_TYPE(HttpStatus.BAD_REQUEST, "FILE_006", "지원하지 않는 파일 형식입니다"),
+    FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "FILE_007", "파일 크기가 제한을 초과했습니다"),
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "FILE_008", "회원을 찾을 수 없습니다"),
+    ;
+
+    private final HttpStatus statusCode;
+    private final String code;
+    private final String message;
+
+    FileErrorCode(HttpStatus statusCode, String code, String message) {
+        this.statusCode = statusCode;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus statusCode() {
+        return this.statusCode;
+    }
+
+    @Override
+    public String code() {
+        return this.code;
+    }
+
+    @Override
+    public String message() {
+        return this.message;
+    }
+}

--- a/src/main/java/io/github/bunmo/file/file/exception/FileException.java
+++ b/src/main/java/io/github/bunmo/file/file/exception/FileException.java
@@ -1,0 +1,10 @@
+package io.github.bunmo.file.file.exception;
+
+import io.github.bunmo.file.common.exception.BusinessException;
+
+public class FileException extends BusinessException {
+
+    public FileException(FileErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/io/github/bunmo/file/file/infrastructure/config/MinioConfig.java
+++ b/src/main/java/io/github/bunmo/file/file/infrastructure/config/MinioConfig.java
@@ -1,0 +1,27 @@
+package io.github.bunmo.file.file.infrastructure.config;
+
+import io.minio.MinioClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class MinioConfig {
+
+    @Value("${minio.endpoint}")
+    private String endpoint;
+
+    @Value("${minio.access-key}")
+    private String accessKey;
+
+    @Value("${minio.secret-key}")
+    private String secretKey;
+
+    @Bean
+    public MinioClient minioClient() {
+        return MinioClient.builder()
+                .endpoint(endpoint)
+                .credentials(accessKey, secretKey)
+                .build();
+    }
+}

--- a/src/main/java/io/github/bunmo/file/file/infrastructure/storage/MinioStorageClient.java
+++ b/src/main/java/io/github/bunmo/file/file/infrastructure/storage/MinioStorageClient.java
@@ -1,0 +1,134 @@
+package io.github.bunmo.file.file.infrastructure.storage;
+
+import io.github.bunmo.file.file.exception.FileErrorCode;
+import io.github.bunmo.file.file.exception.FileException;
+import io.minio.*;
+import io.minio.errors.ErrorResponseException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.InputStream;
+
+@Component
+public class MinioStorageClient implements StorageClient {
+
+    private final MinioClient minioClient;
+    private final String bucket;
+
+    public MinioStorageClient(
+            MinioClient minioClient,
+            @Value("${minio.bucket}") String bucket
+    ) {
+        this.minioClient = minioClient;
+        this.bucket = bucket;
+    }
+
+    @Override
+    public void upload(String objectName, InputStream inputStream, long size, String contentType) {
+        try {
+            minioClient.putObject(
+                    PutObjectArgs.builder()
+                            .bucket(bucket)
+                            .object(objectName)
+                            .stream(inputStream, size, -1)
+                            .contentType(contentType)
+                            .build()
+            );
+        } catch (Exception e) {
+            throw new FileException(FileErrorCode.FILE_UPLOAD_FAILED);
+        }
+    }
+
+    @Override
+    public InputStream download(String objectName) {
+        try {
+            return minioClient.getObject(
+                    GetObjectArgs.builder()
+                            .bucket(bucket)
+                            .object(objectName)
+                            .build()
+            );
+        } catch (ErrorResponseException e) {
+            if ("NoSuchKey".equals(e.errorResponse().code())) {
+                throw new FileException(FileErrorCode.FILE_NOT_FOUND);
+            }
+            throw new FileException(FileErrorCode.FILE_DOWNLOAD_FAILED);
+        } catch (Exception e) {
+            throw new FileException(FileErrorCode.FILE_DOWNLOAD_FAILED);
+        }
+    }
+
+    @Override
+    public void delete(String objectName) {
+        try {
+            minioClient.removeObject(
+                    RemoveObjectArgs.builder()
+                            .bucket(bucket)
+                            .object(objectName)
+                            .build()
+            );
+        } catch (Exception e) {
+            throw new FileException(FileErrorCode.FILE_DELETE_FAILED);
+        }
+    }
+
+    @Override
+    public boolean exists(String objectName) {
+        try {
+            minioClient.statObject(
+                    StatObjectArgs.builder()
+                            .bucket(bucket)
+                            .object(objectName)
+                            .build()
+            );
+            return true;
+        } catch (ErrorResponseException e) {
+            if ("NoSuchKey".equals(e.errorResponse().code())) {
+                return false;
+            }
+            throw new FileException(FileErrorCode.FILE_OPERATION_FAILED);
+        } catch (Exception e) {
+            throw new FileException(FileErrorCode.FILE_OPERATION_FAILED);
+        }
+    }
+
+    @Override
+    public String getETag(String objectName) {
+        try {
+            StatObjectResponse stat = minioClient.statObject(
+                    StatObjectArgs.builder()
+                            .bucket(bucket)
+                            .object(objectName)
+                            .build()
+            );
+            return stat.etag();
+        } catch (ErrorResponseException e) {
+            if ("NoSuchKey".equals(e.errorResponse().code())) {
+                throw new FileException(FileErrorCode.FILE_NOT_FOUND);
+            }
+            throw new FileException(FileErrorCode.FILE_OPERATION_FAILED);
+        } catch (Exception e) {
+            throw new FileException(FileErrorCode.FILE_OPERATION_FAILED);
+        }
+    }
+
+    @Override
+    public String getContentType(String objectName) {
+        try {
+            StatObjectResponse stat = minioClient.statObject(
+                    StatObjectArgs.builder()
+                            .bucket(bucket)
+                            .object(objectName)
+                            .build()
+            );
+            return stat.contentType();
+        } catch (ErrorResponseException e) {
+            if ("NoSuchKey".equals(e.errorResponse().code())) {
+                throw new FileException(FileErrorCode.FILE_NOT_FOUND);
+            }
+            throw new FileException(FileErrorCode.FILE_OPERATION_FAILED);
+        } catch (Exception e) {
+            throw new FileException(FileErrorCode.FILE_OPERATION_FAILED);
+        }
+    }
+}

--- a/src/main/java/io/github/bunmo/file/file/infrastructure/storage/StorageClient.java
+++ b/src/main/java/io/github/bunmo/file/file/infrastructure/storage/StorageClient.java
@@ -1,0 +1,18 @@
+package io.github.bunmo.file.file.infrastructure.storage;
+
+import java.io.InputStream;
+
+public interface StorageClient {
+
+    void upload(String objectName, InputStream inputStream, long size, String contentType);
+
+    InputStream download(String objectName);
+
+    void delete(String objectName);
+
+    boolean exists(String objectName);
+
+    String getETag(String objectName);
+
+    String getContentType(String objectName);
+}

--- a/src/main/java/io/github/bunmo/file/file/presentation/FileController.java
+++ b/src/main/java/io/github/bunmo/file/file/presentation/FileController.java
@@ -1,0 +1,75 @@
+package io.github.bunmo.file.file.presentation;
+
+import io.github.bunmo.file.common.web.ApiResponse;
+import io.github.bunmo.file.file.application.FileService;
+import io.github.bunmo.file.file.application.FileService.ProfileImageData;
+import io.github.bunmo.file.file.presentation.dto.FileResultCode;
+import io.github.bunmo.file.file.presentation.dto.ProfileUploadResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.CacheControl;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.concurrent.TimeUnit;
+
+@Tag(name = "File", description = "파일 관리 API")
+@RestController
+@RequestMapping("/api/v1/files")
+public class FileController {
+
+    private final FileService fileService;
+
+    public FileController(FileService fileService) {
+        this.fileService = fileService;
+    }
+
+    @Operation(summary = "프로필 이미지 업로드", description = "인증된 사용자의 프로필 이미지를 업로드합니다")
+    @PostMapping(value = "/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<ProfileUploadResponse>> uploadProfile(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @Parameter(description = "프로필 이미지 파일")
+            @RequestParam("file") MultipartFile file
+    ) {
+        String uuid = userDetails.getUsername();
+        ProfileUploadResponse response = fileService.uploadProfileImage(uuid, file);
+        return ResponseEntity.ok(ApiResponse.success(FileResultCode.PROFILE_UPLOADED, response));
+    }
+
+    @Operation(summary = "프로필 이미지 조회", description = "UUID로 프로필 이미지를 조회합니다 (인증 불필요)")
+    @GetMapping("/profile/{uuid}")
+    public ResponseEntity<InputStreamResource> getProfile(
+            @Parameter(description = "회원 UUID")
+            @PathVariable String uuid,
+            @RequestHeader(value = HttpHeaders.IF_NONE_MATCH, required = false) String ifNoneMatch
+    ) {
+        ProfileImageData imageData = fileService.getProfileImage(uuid);
+
+        if (ifNoneMatch != null && ifNoneMatch.equals("\"" + imageData.etag() + "\"")) {
+            return ResponseEntity.status(304).build();
+        }
+
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType(imageData.contentType()))
+                .cacheControl(CacheControl.maxAge(1, TimeUnit.DAYS).cachePublic())
+                .eTag(imageData.etag())
+                .body(new InputStreamResource(imageData.inputStream()));
+    }
+
+    @Operation(summary = "프로필 이미지 삭제", description = "인증된 사용자의 프로필 이미지를 삭제합니다")
+    @DeleteMapping("/profile")
+    public ResponseEntity<ApiResponse<Void>> deleteProfile(
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        String uuid = userDetails.getUsername();
+        fileService.deleteProfileImage(uuid);
+        return ResponseEntity.ok(ApiResponse.success(FileResultCode.PROFILE_DELETED, null));
+    }
+}

--- a/src/main/java/io/github/bunmo/file/file/presentation/FileController.java
+++ b/src/main/java/io/github/bunmo/file/file/presentation/FileController.java
@@ -3,11 +3,9 @@ package io.github.bunmo.file.file.presentation;
 import io.github.bunmo.file.common.web.ApiResponse;
 import io.github.bunmo.file.file.application.FileService;
 import io.github.bunmo.file.file.application.FileService.ProfileImageData;
+import io.github.bunmo.file.file.presentation.doc.FileControllerDoc;
 import io.github.bunmo.file.file.presentation.dto.FileResultCode;
 import io.github.bunmo.file.file.presentation.dto.ProfileUploadResponse;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.core.io.InputStreamResource;
 import org.springframework.http.CacheControl;
 import org.springframework.http.HttpHeaders;
@@ -20,10 +18,9 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.concurrent.TimeUnit;
 
-@Tag(name = "File", description = "파일 관리 API")
 @RestController
 @RequestMapping("/api/v1/files")
-public class FileController {
+public class FileController implements FileControllerDoc {
 
     private final FileService fileService;
 
@@ -31,11 +28,10 @@ public class FileController {
         this.fileService = fileService;
     }
 
-    @Operation(summary = "프로필 이미지 업로드", description = "인증된 사용자의 프로필 이미지를 업로드합니다")
+    @Override
     @PostMapping(value = "/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<ProfileUploadResponse>> uploadProfile(
             @AuthenticationPrincipal UserDetails userDetails,
-            @Parameter(description = "프로필 이미지 파일")
             @RequestParam("file") MultipartFile file
     ) {
         String uuid = userDetails.getUsername();
@@ -43,14 +39,14 @@ public class FileController {
         return ResponseEntity.ok(ApiResponse.success(FileResultCode.PROFILE_UPLOADED, response));
     }
 
-    @Operation(summary = "프로필 이미지 조회", description = "UUID로 프로필 이미지를 조회합니다 (인증 불필요)")
-    @GetMapping("/profile/{uuid}")
+    @Override
+    @GetMapping("/{uuid}/profile/{timestamp}")
     public ResponseEntity<InputStreamResource> getProfile(
-            @Parameter(description = "회원 UUID")
             @PathVariable String uuid,
+            @PathVariable String timestamp,
             @RequestHeader(value = HttpHeaders.IF_NONE_MATCH, required = false) String ifNoneMatch
     ) {
-        ProfileImageData imageData = fileService.getProfileImage(uuid);
+        ProfileImageData imageData = fileService.getProfileImage(uuid, Long.parseLong(timestamp));
 
         if (ifNoneMatch != null && ifNoneMatch.equals("\"" + imageData.etag() + "\"")) {
             return ResponseEntity.status(304).build();
@@ -61,15 +57,5 @@ public class FileController {
                 .cacheControl(CacheControl.maxAge(1, TimeUnit.DAYS).cachePublic())
                 .eTag(imageData.etag())
                 .body(new InputStreamResource(imageData.inputStream()));
-    }
-
-    @Operation(summary = "프로필 이미지 삭제", description = "인증된 사용자의 프로필 이미지를 삭제합니다")
-    @DeleteMapping("/profile")
-    public ResponseEntity<ApiResponse<Void>> deleteProfile(
-            @AuthenticationPrincipal UserDetails userDetails
-    ) {
-        String uuid = userDetails.getUsername();
-        fileService.deleteProfileImage(uuid);
-        return ResponseEntity.ok(ApiResponse.success(FileResultCode.PROFILE_DELETED, null));
     }
 }

--- a/src/main/java/io/github/bunmo/file/file/presentation/doc/FileControllerDoc.java
+++ b/src/main/java/io/github/bunmo/file/file/presentation/doc/FileControllerDoc.java
@@ -1,0 +1,32 @@
+package io.github.bunmo.file.file.presentation.doc;
+
+import io.github.bunmo.file.common.web.ApiResponse;
+import io.github.bunmo.file.file.presentation.dto.ProfileUploadResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.multipart.MultipartFile;
+
+@Tag(name = "File", description = "파일 관리 API")
+public interface FileControllerDoc {
+    @Operation(summary = "프로필 이미지 업로드", description = "인증된 사용자의 프로필 이미지를 업로드합니다")
+    ResponseEntity<ApiResponse<ProfileUploadResponse>> uploadProfile(
+            @Parameter(hidden = true)
+            UserDetails userDetails,
+            @Parameter(description = "프로필 이미지 파일")
+            MultipartFile file
+    );
+
+    @Operation(summary = "프로필 이미지 조회", description = "UUID로 프로필 이미지를 조회합니다 (인증 불필요)")
+    ResponseEntity<InputStreamResource> getProfile(
+            @Parameter(description = "회원 UUID")
+            @PathVariable String uuid,
+            @Parameter(description = "캐시 버스팅용 타임스탬프")
+            @PathVariable String timestamp,
+            String ifNoneMatch
+    );
+}

--- a/src/main/java/io/github/bunmo/file/file/presentation/dto/FileResultCode.java
+++ b/src/main/java/io/github/bunmo/file/file/presentation/dto/FileResultCode.java
@@ -1,0 +1,35 @@
+package io.github.bunmo.file.file.presentation.dto;
+
+import io.github.bunmo.file.common.web.ResultCode;
+import org.springframework.http.HttpStatus;
+
+public enum FileResultCode implements ResultCode {
+    PROFILE_UPLOADED(HttpStatus.OK, "FILE_001", "프로필 이미지가 업로드되었습니다"),
+    PROFILE_DELETED(HttpStatus.OK, "FILE_002", "프로필 이미지가 삭제되었습니다"),
+    ;
+
+    private final HttpStatus statusCode;
+    private final String code;
+    private final String message;
+
+    FileResultCode(HttpStatus statusCode, String code, String message) {
+        this.statusCode = statusCode;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus statusCode() {
+        return this.statusCode;
+    }
+
+    @Override
+    public String code() {
+        return this.code;
+    }
+
+    @Override
+    public String message() {
+        return this.message;
+    }
+}

--- a/src/main/java/io/github/bunmo/file/file/presentation/dto/ProfileUploadResponse.java
+++ b/src/main/java/io/github/bunmo/file/file/presentation/dto/ProfileUploadResponse.java
@@ -4,13 +4,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "프로필 이미지 업로드 응답")
 public record ProfileUploadResponse(
-        @Schema(description = "회원 UUID", example = "550e8400-e29b-41d4-a716-446655440000")
-        String uuid,
-
-        @Schema(description = "프로필 이미지 URL", example = "/api/v1/files/profile/550e8400-e29b-41d4-a716-446655440000")
+        @Schema(description = "프로필 이미지 URL", example = "/profile/550e8400-e29b-41d4-a716-446655440000/1706951234")
         String profileUrl
 ) {
-    public static ProfileUploadResponse of(String uuid) {
-        return new ProfileUploadResponse(uuid, "/api/v1/files/profile/" + uuid);
+    public static ProfileUploadResponse of(String profileUrl) {
+        return new ProfileUploadResponse(profileUrl);
     }
 }

--- a/src/main/java/io/github/bunmo/file/file/presentation/dto/ProfileUploadResponse.java
+++ b/src/main/java/io/github/bunmo/file/file/presentation/dto/ProfileUploadResponse.java
@@ -1,0 +1,16 @@
+package io.github.bunmo.file.file.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "프로필 이미지 업로드 응답")
+public record ProfileUploadResponse(
+        @Schema(description = "회원 UUID", example = "550e8400-e29b-41d4-a716-446655440000")
+        String uuid,
+
+        @Schema(description = "프로필 이미지 URL", example = "/api/v1/files/profile/550e8400-e29b-41d4-a716-446655440000")
+        String profileUrl
+) {
+    public static ProfileUploadResponse of(String uuid) {
+        return new ProfileUploadResponse(uuid, "/api/v1/files/profile/" + uuid);
+    }
+}

--- a/src/main/java/io/github/bunmo/file/member/domain/Member.java
+++ b/src/main/java/io/github/bunmo/file/member/domain/Member.java
@@ -2,6 +2,7 @@ package io.github.bunmo.file.member.domain;
 
 import io.github.bunmo.file.member.domain.enums.ActiveType;
 import io.github.bunmo.file.member.domain.enums.RoleType;
+import io.github.bunmo.file.member.domain.vo.MemberProfile;
 import jakarta.persistence.*;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -15,6 +16,9 @@ public class Member {
 
     @Column(nullable = false, unique = true, updatable = false)
     private String uuid;
+
+    @Embedded
+    private MemberProfile memberProfile;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "active_type", nullable = false)
@@ -31,5 +35,13 @@ public class Member {
 
     public RoleType role() {
         return role;
+    }
+
+    public String getProfileImageUrl() {
+        return memberProfile != null ? memberProfile.profileImageUrl() : null;
+    }
+
+    public void updateProfileImageUrl(String profileImageUrl) {
+        this.memberProfile = new MemberProfile(profileImageUrl);
     }
 }

--- a/src/main/java/io/github/bunmo/file/member/domain/vo/MemberProfile.java
+++ b/src/main/java/io/github/bunmo/file/member/domain/vo/MemberProfile.java
@@ -1,0 +1,9 @@
+package io.github.bunmo.file.member.domain.vo;
+
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public record MemberProfile(
+        String profileImageUrl
+) {
+}

--- a/src/main/java/io/github/bunmo/file/security/config/SecurityConfig.java
+++ b/src/main/java/io/github/bunmo/file/security/config/SecurityConfig.java
@@ -77,7 +77,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/api-docs/**",
-                                "/swagger-ui/**"
+                                "/swagger-ui/**",
+                                "/api/v1/files/profile/*"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/io/github/bunmo/file/security/config/SecurityConfig.java
+++ b/src/main/java/io/github/bunmo/file/security/config/SecurityConfig.java
@@ -5,6 +5,7 @@ import io.github.bunmo.file.security.jwt.JwtAccessDeniedHandler;
 import io.github.bunmo.file.security.jwt.JwtAuthenticationEntryPoint;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -76,11 +77,13 @@ public class SecurityConfig {
                         .accessDeniedHandler(jwtAccessDeniedHandler))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
+                                HttpMethod.POST, "/api/v1/files/profile"
+                        ).authenticated()
+                        .requestMatchers(
                                 "/api-docs/**",
                                 "/swagger-ui/**",
-                                "/api/v1/files/profile/*"
+                                "/api/v1/files/**"
                         ).permitAll()
-                        .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();


### PR DESCRIPTION
# 작업 사항
  - MinIO를 사용한 프로필 이미지 업로드/다운로드 기능 구현                                                                                                                                                                          
  - 이미지 캐싱을 위한 타임스탬프 기반 파일 경로 설계                                                                                                                                                                               
  - 파일 서비스 패키지 구조 및 예외 처리 추가

# 신규 기능
- 업로드 /api/v1/files/profile 
  - 프로필 업로드시 인증 필요
- 조회 /api/v1/files/{uuid}/profile/{timestamp}
  - 프로필 이미지 조회시 인증 불필요

# 참고 사항
- MinIO 사용을 위해 docker compose 구축
- MySQL은 기존 api 서버에서 사용하는 RDB를 사용하므로 이를 먼저 실행하고 file api server를 실행 시켜야 함